### PR TITLE
Remove section about coverage calculation simplification

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,10 +178,6 @@ The reference `SolveHorizPoly()` falls back to a linear solve when the quadratic
 
 The reference has separate `SolveHorizPoly` and `SolveVertPoly` functions. Forme eliminates `SolveVertPoly` by swapping the x and y components of the control points before passing them to `SolveHorizPoly`, reducing code duplication.
 
-### Coverage calculation simplified.
-
-The reference `CalcCoverage()` tracks per-ray coverage weights (`xwgt`, `ywgt`) to blend horizontal and vertical ray contributions, and supports `SLUG_EVENODD` and `SLUG_WEIGHT` compile-time modes. Forme uses a simpler `(covX + covY) * 0.5` average, which produces correct results for standard nonzero fill rule rendering without the additional weight tracking.
-
 ## Third-Party Credits
 
 ### Slug Algorithm


### PR DESCRIPTION
## Prerequisites
- [x] I have verified that there are no existing pull requests that would overlap with this pull request.
- [x] I have verified that I am following the guidelines as outlined in this project's contribution policy
- [x] I Have verified that this pull request adheres to this project's code of conduct.
- [x] I have written a descriptive title for this pull request.
- [x] I have provided appropriate test coverage were applicable.

## Description
Removes the coverage calculation simplification section from the notes about the conversion of slug to MonoGame's SM3 support.  This was a bad design decision simplifying it and caused harsher rendering. Implemented the weights in #2 

## Related Issue Ticket Numbers
- #1 
